### PR TITLE
Refactored to new design

### DIFF
--- a/runtime/src/include/45/ompt.h.var
+++ b/runtime/src/include/45/ompt.h.var
@@ -132,9 +132,9 @@
     macro (ompt_event_control,                  ompt_control_callback_t,       29) /* support control calls */  \
                                                                                                                 \
     /*--- Custom Events (part of extensions to generate grain graphs ---*/                                      \
-    macro (ext_callback_task_create_begin,      ext_callback_task_create_begin_t, 80) /* end of task creation */\
     macro (ext_callback_loop,                   ext_callback_loop_t,              81) /* loop construct */      \
-    macro (ext_callback_chunk,         ext_callback_chunk_t,    82) /* chunk is scheduled */  \
+    macro (ext_callback_chunk,                  ext_callback_chunk_t,             82) /* chunk is scheduled */  \
+    macro (ext_tool_time,                       ext_tool_time_t,                  83) /* tool-controlled time*/ \
 
 
 
@@ -351,20 +351,15 @@ typedef void (*ompt_callback_task_schedule_t) (
     ompt_task_data_t *second_task_data
 );
 
+// PVL - added duration parameter
 typedef void (*ompt_callback_task_create_t) (
     ompt_data_t *parent_task_data,    /* data of parent task         */
     const ompt_frame_t *parent_frame,       /* frame data for parent task   */
     ompt_data_t *new_task_data,       /* data of created task         */
     ompt_task_type_t type,
     int has_dependences,
+    double event_duration,
     const void *codeptr_ra
-);
-
-/* PVL: custom type */
-typedef void (*ext_callback_task_create_begin_t) (
-    ompt_data_t *parent_task_data,
-    const ompt_frame_t *parent_frame,
-    ompt_task_type_t type
 );
 
 /* task dependences */
@@ -474,11 +469,12 @@ typedef void (*ext_callback_loop_t) (
     ompt_scope_endpoint_t endpoint,
     ompt_data_t * parallel_data,    // The parallel region
     ompt_data_t * task_data,        // The implicit task of the worker
-    int64_t lower,                 // Lower iteration bound
-    int64_t upper,                 // Upper iteration bound
-    int64_t step,                  // Increment
+    int is_iter_signed,             // Signedness of iteration var.
+    int64_t lower,                  // Lower iteration bound
+    int64_t upper,                  // Upper iteration bound
+    int64_t step,                   // Increment
     uint64_t chunk_size,            // Chunk size
-    int64_t thread_lower,          // Lower iter. bound for thread
+    int64_t thread_lower,           // Lower iter. bound for thread
     const void * codeptr_ra
 );
 #else // OMPT_STATIC_CHUNKS is defined
@@ -487,6 +483,7 @@ typedef void (*ext_callback_loop_t) (
     ompt_scope_endpoint_t endpoint,
     ompt_data_t * parallel_data,    // The parallel region
     ompt_data_t * task_data,        // The implicit task of the worker
+    int is_iter_signed,             // Signedness of iteration var.
     int64_t step,                   // Increment
     const void * codeptr_ra
 );
@@ -497,8 +494,12 @@ typedef void (*ext_callback_chunk_t) (
     ompt_data_t *task_data,
     int64_t lower,
     int64_t upper,
+    double create_duration,
     int last_chunk // Is scheduled chunk last for thread?
 );
+
+/* PVL: custom type */
+typedef double (*ext_tool_time_t) (void);
 
 typedef enum ompt_sync_region_kind_e {
     ompt_sync_region_barrier = 1,

--- a/runtime/src/kmp_csupport.cpp
+++ b/runtime/src/kmp_csupport.cpp
@@ -1693,6 +1693,7 @@ __kmpc_for_static_fini( ident_t *loc, kmp_int32 global_tid )
             ompt_scope_end,
             &(team_info->parallel_data),
             &(task_info->task_data),
+            0,
 #ifndef OMPT_STATIC_CHUNKS
             0,
             0,

--- a/runtime/src/kmp_os.h
+++ b/runtime/src/kmp_os.h
@@ -184,6 +184,7 @@ typedef double  kmp_real64;
 #define  KMP_INT_MIN     ((kmp_int32)0x80000000)
 
 #ifdef __cplusplus
+    // PVL: Modified these to indicate whether type is signed
     //-------------------------------------------------------------------------
     // template for debug prints specification ( d, u, lld, llu ), and to obtain
     // signed/unsigned flavors of a type
@@ -199,6 +200,7 @@ typedef double  kmp_real64;
         static const signed_t max_value = 0x7fffffff;
         static const signed_t min_value = 0x80000000;
         static const int type_size = sizeof(signed_t);
+        static const int is_signed = 1;
     };
     // unsigned int
     template<>
@@ -210,6 +212,7 @@ typedef double  kmp_real64;
         static const unsigned_t max_value = 0xffffffff;
         static const unsigned_t min_value = 0x00000000;
         static const int type_size = sizeof(unsigned_t);
+        static const int is_signed = 0;
     };
     // long long
     template<>
@@ -221,6 +224,7 @@ typedef double  kmp_real64;
         static const signed_t max_value = 0x7fffffffffffffffLL;
         static const signed_t min_value = 0x8000000000000000LL;
         static const int type_size = sizeof(signed_t);
+        static const int is_signed = 1;
     };
     // unsigned long long
     template<>
@@ -232,6 +236,7 @@ typedef double  kmp_real64;
         static const unsigned_t max_value = 0xffffffffffffffffLL;
         static const unsigned_t min_value = 0x0000000000000000LL;
         static const int type_size = sizeof(unsigned_t);
+        static const int is_signed = 0;
     };
     //-------------------------------------------------------------------------
 #endif // __cplusplus

--- a/runtime/src/kmp_sched.cpp
+++ b/runtime/src/kmp_sched.cpp
@@ -72,7 +72,7 @@ __kmp_for_static_init(
 #if OMPT_SUPPORT && OMPT_OPTIONAL
     ompt_team_info_t *team_info = NULL;
     ompt_task_info_t *task_info = NULL;
-    // TODO: (PVL) Improve
+    // PVL: Store global lower and upper before they are tailored to thread
     T lower = *plower;
     T upper = *pupper;
 
@@ -137,14 +137,15 @@ __kmp_for_static_init(
                 ompt_scope_begin,
                 &(team_info->parallel_data),
                 &(task_info->task_data),
+                traits_t< T >::is_signed,
 #ifndef OMPT_STATIC_CHUNKS
                 lower,
                 upper,
 #endif
-                incr,
+                incr,                       // Currently always one because of OMP codegen
 #ifndef OMPT_STATIC_CHUNKS
                 (*pupper - *plower + 1),    // Chunk size
-                *plower,        // Thread. lower
+                *plower,                    // Thread. lower
 #endif
                 team_info->microtask);
         }
@@ -200,6 +201,7 @@ __kmp_for_static_init(
                 ompt_scope_begin,
                 &(team_info->parallel_data),
                 &(task_info->task_data),
+                traits_t< T >::is_signed,
 #ifndef OMPT_STATIC_CHUNKS
                 lower,
                 upper,
@@ -207,7 +209,7 @@ __kmp_for_static_init(
                 incr,
 #ifndef OMPT_STATIC_CHUNKS
                 (*pupper - *plower + 1),    // Chunk size
-                *plower,        // Thread. lower
+                *plower,                    // Thread. lower
 #endif
                 team_info->microtask);
         }
@@ -242,14 +244,15 @@ __kmp_for_static_init(
                 ompt_scope_begin,
                 &(team_info->parallel_data),
                 &(task_info->task_data),
+                traits_t< T >::is_signed,
 #ifndef OMPT_STATIC_CHUNKS
                 lower,
                 upper,
 #endif
-                incr,
+                incr,                       // Currently always one because of OMP codegen
 #ifndef OMPT_STATIC_CHUNKS
                 (*pupper - *plower + 1),    // Chunk size
-                *plower,        // Thread. lower
+                *plower,                    // Thread. lower
 #endif
                 team_info->microtask);
         }
@@ -410,14 +413,15 @@ __kmp_for_static_init(
             ompt_scope_begin,
             &(team_info->parallel_data),
             &(task_info->task_data),
+            traits_t< T >::is_signed,
 #ifndef OMPT_STATIC_CHUNKS
             lower,
             upper,
 #endif
-            incr,
+            incr,                       // Currently always one because of OMP codegen
 #ifndef OMPT_STATIC_CHUNKS
             (*pupper - *plower + 1),    // Chunk size
-            *plower,        // Thread. lower
+            *plower,                    // Thread. lower
 #endif
             team_info->microtask);
     }
@@ -809,6 +813,7 @@ __kmp_for_static_chunk(
                 &(task_info->task_data),
                 (int64_t)lower,  // chunk lb
                 (int64_t)upper,  // chunk ub
+                0,               // cannot find create_duration for static chunks
                 last); // last chunk?
     }
 #endif

--- a/runtime/src/kmp_taskdeps.cpp
+++ b/runtime/src/kmp_taskdeps.cpp
@@ -449,12 +449,20 @@ __kmpc_omp_task_with_deps( ident_t *loc_ref, kmp_int32 gtid, kmp_task_t * new_ta
         if (ompt_callbacks.ompt_callback(ompt_callback_task_create)) {
             kmp_taskdata_t *parent = new_taskdata->td_parent;
             ompt_task_data_t task_data = ompt_task_id_none;
+            double start =
+                __kmp_threads[ gtid ]->th.ompt_thread_info.last_tool_time;
+            double now;
+            if (ompt_callbacks.ompt_callback(ext_tool_time))
+                now = ompt_callbacks.ompt_callback(ext_tool_time)();
+            else
+                __kmp_elapsed(&now);
             ompt_callbacks.ompt_callback(ompt_callback_task_create)(
                 parent ? &(parent->ompt_task_info.task_data) : &task_data,
                 parent ? &(parent->ompt_task_info.frame) : NULL,
                 &(new_taskdata->ompt_task_info.task_data),
                 ompt_task_explicit,
                 1,
+                now-start,
                 new_taskdata->ompt_task_info.function);
         }
 

--- a/runtime/src/ompt-event-specific.h
+++ b/runtime/src/ompt-event-specific.h
@@ -86,9 +86,9 @@
 
 // Start of PVLangdal extensions
 
-#define ext_callback_task_create_begin_implemented      ompt_event_MAY_ALWAYS
 #define ext_callback_loop_implemented                   ompt_event_MAY_ALWAYS
 #define ext_callback_chunk_implemented                  ompt_event_MAY_ALWAYS
+#define ext_tool_time_implemented                       ompt_event_MAY_ALWAYS
 
 // End of PVLangdal extensions
 

--- a/runtime/src/ompt-general.cpp
+++ b/runtime/src/ompt-general.cpp
@@ -270,6 +270,7 @@ void ompt_post_init()
                 task_data,
                 ompt_task_initial,
                 0,
+                0,
                 OMPT_GET_RETURN_ADDRESS(0));
         }
 

--- a/runtime/src/ompt-internal.h
+++ b/runtime/src/ompt-internal.h
@@ -58,12 +58,13 @@ typedef struct ompt_lw_taskteam_s {
 //    void *parallel_function;          /* pointer to outlined function */
 //} ompt_parallel_info_t;
 
-
+// PVL: Added last_tool_time
 typedef struct {
     ompt_thread_data_t  thread_data;
     ompt_parallel_data_t  parallel_data; /* stored here from implicit barrier-begin until implicit-task-end */
     ompt_state_t        state;
     ompt_wait_id_t      wait_id;
+    double              last_tool_time;
     void                *idle_frame;
 } ompt_thread_info_t;
 


### PR DESCRIPTION
Changes:
- ompt_callback_task_create and ext_callback_chunk now has a duration
  parameter of type double. To calculate this, it checks if
  the ext_tool_time callback has been registered by the tool. If it is,
  it is used to find start and end time instants. If not, it uses an
  internal equivalent to omp_get_wtime.
- New function signatures